### PR TITLE
Added new methods to implement optional buffer to

### DIFF
--- a/examples/WithoutDelay/WithoutDelay.ino
+++ b/examples/WithoutDelay/WithoutDelay.ino
@@ -1,0 +1,138 @@
+#include <Arduino.h>
+
+/*
+  Thermistor.
+
+  Reads a temperature from the NTC 3950 thermistor and displays
+  it in the default Serial.
+
+  https://github.com/YuriiSalimov/NTC_Thermistor
+
+  Created by Oséias Ferreira, January, 2019
+  based on code written by Yuri Shalimov, April, 2018.
+  Released into the public domain.
+*/
+#include <NTC_Thermistor.h>
+
+#define SENSOR_PIN             A1
+#define REFERENCE_RESISTANCE   8000
+#define NOMINAL_RESISTANCE     100000
+#define NOMINAL_TEMPERATURE    25
+#define B_VALUE                3950
+
+/**
+   How many readings are taken to determine a mean temperature.
+   The more values, the longer a calibration is performed,
+   but the readings will be more accurate.
+*/
+#define READINGS_NUMBER 10
+
+/**
+   Delay time between a temperature readings
+   from the temperature sensor (ms).
+*/
+#define DELAY_TIME 20
+
+#define DELAY_ENABLE false
+
+const int printInterval = 2000; //sec
+long lastPrint = 0;
+
+uint8_t numRead = 10;
+
+NTC_Thermistor* thermistor = NULL;
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("NTC_Thermistor Disable Delay example.");
+  thermistor = new NTC_Thermistor(
+    SENSOR_PIN,
+    REFERENCE_RESISTANCE,
+    NOMINAL_RESISTANCE,
+    NOMINAL_TEMPERATURE,
+    B_VALUE,
+    READINGS_NUMBER,
+    DELAY_TIME,
+    DELAY_ENABLE
+  );
+  /* or
+    thermistor = new NTC_Thermistor(
+      SENSOR_PIN,
+      REFERENCE_RESISTANCE,
+      NOMINAL_RESISTANCE,
+      NOMINAL_TEMPERATURE,
+      B_VALUE
+    );
+    thermistor->setReadingsNumber(READINGS_NUMBER);
+    thermistor->setDelayTime(DELAY_TIME);
+    thermistor->setUseDelay(DELAY_ENABLE);
+  */
+
+  // start first read
+  thermistor->startRead();
+}
+
+void loop() {
+  unsigned long now = millis(); // to control Serial.print
+  unsigned long now_us = 0;     // to measure spent time
+
+  if (thermistor->isReading()){
+    now_us = micros();
+    if (thermistor->Update(now)) {
+      unsigned long updateTime = micros() - now_us;
+      Serial.print("updateTime: ");
+      Serial.println(String(updateTime) + " us");
+    }
+  }
+  else{ //read is finished
+    if (now - lastPrint > printInterval){ // print only after wait printInterval
+
+      now_us = micros(); // reset
+
+      double celsius = thermistor->readCelsius();
+      double kelvin = thermistor->readKelvin();
+      double fahrenheit = thermistor->readFahrenheit();
+
+      unsigned long readTime = micros() - now_us;
+
+      Serial.print("NoDelay\t");
+      Serial.print("Temperature: ");
+      Serial.print(String(celsius) + " C, ");
+      Serial.print(String(kelvin) + " K, ");
+      Serial.print(String(fahrenheit) + " F ");
+      Serial.print("readTime: ");
+      Serial.println(String(readTime) + " us ");
+
+      //enable delay
+      thermistor->setUseDelay(true);
+
+      now_us = micros(); // reset
+
+      celsius = thermistor->readCelsius();
+      kelvin = thermistor->readKelvin();
+      fahrenheit = thermistor->readFahrenheit();
+
+      readTime = micros() - now_us;
+
+      Serial.print("Delay\t");
+      Serial.print("Temperature: ");
+      Serial.print(String(celsius) + " C, ");
+      Serial.print(String(kelvin) + " K, ");
+      Serial.print(String(fahrenheit) + " F ");
+      Serial.print("ReadTime: ");
+      Serial.println(String(readTime) + " us ");
+
+      //disable delay
+      thermistor->setUseDelay(false);
+      numRead++;
+      thermistor->setReadingsNumber(numRead);
+      if (numRead == 20) numRead=5;
+
+
+      lastPrint = now;
+
+      // read again
+      thermistor->startRead();
+    }
+  }
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,9 +12,13 @@ NTC_Thermistor	KEYWORD1
 #    Methods and Functions (KEYWORD2)    #
 ##########################################
 
+Update	KEYWORD2
+isReading	KEYWORD2
 readCelsius	KEYWORD2
-readKelvin	KEYWORD2
 readFahrenheit	KEYWORD2
 readFarenheit	KEYWORD2
-setReadingsNumber	KEYWORD2
+readKelvin	KEYWORD2
 setDelayTime	KEYWORD2
+setReadingsNumber	KEYWORD2
+setUseDelay	KEYWORD2
+startRead	KEYWORD2


### PR DESCRIPTION
store analog port timed readings, instead of delay interruptions.

  public:
    Update
    isReading
    setUseDelay
    startRead
  private:
    initBuffer
    readBuffer

Added variables
    bool useDelay;
    double *analogBuffer;
    unsigned int bufferId;
    long lastRead;
    bool enableRead;

Added constructor to set delay or buffer option.
Added example to use this library without delay() interruptions.
Updated keywords.txt.
Removed unused volatile variables (it does not use interrupts).