### PR TITLE
add virtual destructors on base classes to avoid undefined behavior

### DIFF
--- a/src/NTC_Thermistor.cpp
+++ b/src/NTC_Thermistor.cpp
@@ -20,6 +20,9 @@ NTC_Thermistor::NTC_Thermistor(
 	this->adcResolution = max(adcResolution, 0);
 }
 
+NTC_Thermistor::~NTC_Thermistor() {
+}
+
 /**
 	Reads and returns a temperature in Celsius.
 	Reads the temperature in Kelvin,

--- a/src/NTC_Thermistor.h
+++ b/src/NTC_Thermistor.h
@@ -76,6 +76,12 @@ class NTC_Thermistor : public Thermistor {
     );
 
     /**
+      Destructor
+      Deletes the base NTC_Thermistor instance.
+    */
+    virtual ~NTC_Thermistor();
+
+    /**
       Reads a temperature in Celsius from the thermistor.
 
       @return temperature in degree Celsius

--- a/src/Thermistor.cpp
+++ b/src/Thermistor.cpp
@@ -1,0 +1,4 @@
+#include "Thermistor.h"
+
+Thermistor::~Thermistor() {
+}

--- a/src/Thermistor.h
+++ b/src/Thermistor.h
@@ -23,6 +23,12 @@
 class Thermistor {
 
 	public:
+    /**
+      Destructor
+      Deletes the base Thermistor instance.
+    */
+    virtual ~Thermistor();
+  
 		/**
 			Reads a temperature in Celsius from the thermistor.
 


### PR DESCRIPTION
I added virtual destructors to the base classes - Thermistor and NTC_Thermistor to avoid undefined behaviour and silence warnings from the platformio compiler. This is the warning in question:

```error: deleting object of abstract class type 'Thermistor' which has non-virtual destructor will cause undefined behaviour [-Werror=delete-non-virtual-dtor]```