### PR TITLE
Update for more accurate ESP32-C3 samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
 # NTC Thermistor Library
 
-For Arduino ant STM32 boards.
+For Arduino, ESP32 and STM32 boards.
+
+Enhanced in 2024 by Bob Wolff to support more accurate NTC results
+on ESP32 devices. Some of the ESP32 devices like the ESP32-C3 have
+the ADC raw count values as "uncalibrated" results while the
+millivolt reading from analogReadMillivolts() are calibrated and
+are quite a bit more accurate. Instantiating NTC_Thermistor_ESP32
+and passing in the voltage reference in millivoltes (likely 3300),
+this derived class will give more accurate results for temperatures.
 
 The Library implements a set of methods for working with a NTC thermistor.
 Provides a temperature reading in Celsius, Fahrenheit and Kelvin.
 
 ## Installation
 
-1. [Download](https://github.com/YuriiSalimov/NTC_Thermistor/releases) the Latest release from gitHub.
+1. [Download](https://github.com/bobwolff68/NTC_Thermistor/releases) the Latest release from gitHub.
 2. Unzip and modify the Folder name to "NTC_Thermistor" (Remove the '-version')
 3. Paste the modified folder on your Library folder (On your `libraries` folder inside Sketchbooks or Arduino software).
 4. Restart the Arduino IDE.
 
 ## Circuit Diagram
 
-Connect to the analog side of an Arduino Uno. Run GND through the thermistor, then a pull-down resistor (R0), and into 5V. To measure the temperature pull a line off the junction of the thermistor and the resistor, and into an analog pin (A1 here).
+Connect to the analog side of an Arduino Uno. Run GND through the thermistor, then a pull-down resistor (R0), and into reference voltage. To measure the temperature pull a line off the junction of the thermistor and the resistor, and into an analog pin (A1 here).
 
 ![Diagram](Diagram.png)
 

--- a/examples/ESP32/ESP32.c
+++ b/examples/ESP32/ESP32.c
@@ -1,0 +1,59 @@
+/*
+  NTC Thermistor for ESP32 higher accuracy results
+
+  Reads a temperature from the NTC 3950 thermistor and displays
+  it in the default Serial.
+
+  ESP32 devices are 12-bit ADC devices so the defuault is 4095 here.
+
+  https://github.com/bobwolff68/NTC_Thermistor
+
+  Created by Bob Wolff from Yuri's original - 2024
+  Released into the public domain.
+*/
+#include <Thermistor.h>
+#include <NTC_Thermistor.h>
+
+#define SENSOR_PIN              3
+#define REFERENCE_RESISTANCE    10000
+#define NOMINAL_RESISTANCE      10000
+#define NOMINAL_TEMPERATURE     25
+#define B_VALUE                 3950
+#define ESP32_ANALOG_RESOLUTION 4095
+#define ESP32_ADC_VREF_MV       3300
+
+Thermistor* thermistor;
+
+// the setup function runs once when you press reset or power the board
+void setup() {
+  Serial.begin(9600);
+
+  thermistor = new NTC_Thermistor_ESP32(
+    SENSOR_PIN,
+    REFERENCE_RESISTANCE,
+    NOMINAL_RESISTANCE,
+    NOMINAL_TEMPERATURE,
+    B_VALUE,
+    ESP32_ADC_VREF_MV,
+    ESP32_ANALOG_RESOLUTION
+  );
+}
+
+// the loop function runs over and over again forever
+void loop() {
+  // Reads temperature
+  const double celsius = thermistor->readCelsius();
+  const double kelvin = thermistor->readKelvin();
+  const double fahrenheit = thermistor->readFahrenheit();
+
+  // Output of information
+  Serial.print("Temperature: ");
+  Serial.print(celsius);
+  Serial.print(" C, ");
+  Serial.print(kelvin);
+  Serial.print(" K, ");
+  Serial.print(fahrenheit);
+  Serial.println(" F");
+
+  delay(500); // optionally, only to delay the output of information in the example.
+}

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=NTC_Thermistor
-version=2.0.3
-author=Yurii Salimov <yuriy.alex.salimov@gmail.com>
+version=2.1.0
+author=Yurii Salimov <yuriy.alex.salimov@gmail.com> and Bob Wolff
 maintainer=Yurii Salimov <yuriy.alex.salimov@gmail.com>
 sentence=The Library implements a set of methods for working with a NTC thermistor.
 paragraph=Provides a temperature reading in Celsius, Fahrenheit and Kelvin.
 category=Sensors
-url=https://github.com/YuriiSalimov/NTC_Thermistor
+url=https://github.com/bobwolff68/NTC_Thermistor
 architectures=*

--- a/src/NTC_Thermistor.h
+++ b/src/NTC_Thermistor.h
@@ -48,6 +48,7 @@ class NTC_Thermistor : public Thermistor {
     // Default analog resolution for Arduino board
     static const int DEFAULT_ADC_RESOLUTION = 1023;
 
+  protected:
     int pin; // an analog port.
     double referenceResistance;
     double nominalResistance;
@@ -96,7 +97,7 @@ class NTC_Thermistor : public Thermistor {
     */
     double readFahrenheit() override;
 
-  private:
+  protected:
     /**
       Resistance to Kelvin conversion:
       1/K = 1/K0 + ln(R/R0)/B;
@@ -130,7 +131,7 @@ class NTC_Thermistor : public Thermistor {
 
       @return thermistor voltage in analog range (0...1023, for Arduino).
     */
-    inline double readVoltage();
+    virtual double readVoltage();
 
     /**
       Celsius to Kelvin conversion:
@@ -167,6 +168,43 @@ class NTC_Thermistor : public Thermistor {
       @return temperature in degree Fahrenheit
     */
     inline double kelvinsToFahrenheit(double kelvins);
+};
+
+class NTC_Thermistor_ESP32 : public NTC_Thermistor {
+  public:
+    /**
+      Constructor
+
+      @param pin - an analog port number to be attached to the thermistor
+      @param referenceResistance - reference resistance
+      @param nominalResistance - nominal resistance at a nominal temperature
+      @param nominalTemperature - nominal temperature in Celsius
+      @param bValue - b-value of a thermistor
+      @param adcVref - The ADC's reference voltage (likely 3300 for 3.3volts)
+      @param adcResolution - ADC resolution (default 4095, for ESP32)
+    */
+    NTC_Thermistor_ESP32(
+      int pin,
+      double referenceResistance,
+      double nominalResistance,
+      double nominalTemperatureCelsius,
+      double bValue,
+      uint16_t adcVref,
+      int adcResolution = DEFAULT_ESP32_ADC_RESOLUTION
+    );
+  protected:
+    /**
+      @brief read the calibrated version of the ADC count value indirectly
+      by reading the millivolts value (which is calibrated by Espressif)
+      and back-calculating the raw ADC count value.
+
+      @return thermistor voltage in analog range (0...4095, for ESP32).
+    */
+    virtual double readVoltage();
+  private:
+    // Default analog resolution for Arduino board
+    static const int DEFAULT_ESP32_ADC_RESOLUTION = 4095;
+    uint16_t vref_mv;
 };
 
 #endif


### PR DESCRIPTION
ESP32 devices often suffer from a "calibrated" or "non-calibrated" flavor on the ADC. I had noticed yesterday that my NTC temperatures were all off by a good 4 or 5 degrees F so I looked into it and it turns out analogReadMillivolts() is the calibrated result and that value matched my multimeter measurement in the voltage divider very very well. So I made this derived class that utilizes this more accurate value.