### PR TITLE
Added a preprocessor directive

### DIFF
--- a/src/NTC_Thermistor.cpp
+++ b/src/NTC_Thermistor.cpp
@@ -96,6 +96,7 @@ inline double NTC_Thermistor::kelvinsToFahrenheit(const double kelvins) {
 	return celsiusToFahrenheit(kelvinsToCelsius(kelvins));
 }
 
+#if defined(ESP32)
 /***
  * @brief Slight derivation which reads the 'voltage' (which is
  * really in raw ADC count values) indirectly through reading
@@ -124,3 +125,4 @@ NTC_Thermistor_ESP32::NTC_Thermistor_ESP32(
 double NTC_Thermistor_ESP32::readVoltage() {
 	return (double)analogReadMilliVolts(this->pin) / (double)this->vref_mv * this->adcResolution;
 }
+#endif

--- a/src/NTC_Thermistor.h
+++ b/src/NTC_Thermistor.h
@@ -170,6 +170,7 @@ class NTC_Thermistor : public Thermistor {
     inline double kelvinsToFahrenheit(double kelvins);
 };
 
+#if defined(ESP32)
 class NTC_Thermistor_ESP32 : public NTC_Thermistor {
   public:
     /**
@@ -206,5 +207,5 @@ class NTC_Thermistor_ESP32 : public NTC_Thermistor {
     static const int DEFAULT_ESP32_ADC_RESOLUTION = 4095;
     uint16_t vref_mv;
 };
-
+#endif // ESP32
 #endif


### PR DESCRIPTION
The latest update to NTC_Thermistor added a call to the ESP32-specific function `analogReadMilliVolts()`. This PR wraps that code in the preprocessor directive `#if defined(ESP32)` to ensure that other platforms still compile.